### PR TITLE
handlebars 不用全局注册

### DIFF
--- a/src/seajs-text.js
+++ b/src/seajs-text.js
@@ -44,11 +44,8 @@
         '  var source = "' + jsEscape(content) + '"',
         '  var Handlebars = require("handlebars")',
         '  module.exports = function(data, options) {',
-        '    var helpers = (options || {}).helpers || {}',
-        '    for (var key in helpers) {',
-        '      Handlebars.registerHelper(key, helpers[key])',
-        '    }',
-        '    return Handlebars.compile(source)(data)',
+        '    options || (options = {})',
+        '    return Handlebars.compile(source)(data, options)',
         '  }',
         '})'
       ].join('\n')


### PR DESCRIPTION
现在使用 registerHelper 来注册 helper，但这种做法不支持 partials。

因为编译后的函数本身就支持 options，所以这样修改就简单很多了

https://github.com/wycats/handlebars.js/blob/1.0.0/lib/handlebars/runtime.js#L36

还有 seajs 用例里最好加下 partials 的测试。
